### PR TITLE
JSOO Support

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -4,11 +4,9 @@ steps:
   - task: NodeTool@0
     inputs:
       versionSpec: '8.9'
-  - script: npm install -g esy@0.3.4
-  - script: esy install
-    continueOnError: true
-  - script: esy install
-    continueOnError: true
+  - script: npm install -g esy@0.4.1
   - script: esy install
   - script: esy build
-  - script: esy b dune runtest --no-buffer
+  - script: esy test:native
+  - script: esy build:js
+  - script: esy test:js

--- a/lib/Rejest.re
+++ b/lib/Rejest.re
@@ -26,9 +26,6 @@ let test = (name: string, testFunction: testFunction) =>
     );
   };
 
-open LTerm_style;
-open LTerm_text;
-
 let run = () => {
   /* For each 'queued' test, call the in-aplty named `collectTest` */
   /* How do we wait for all Lwt promises? */
@@ -42,10 +39,10 @@ let run = () => {
     );
     isRunning := false;
 
-    let%lwt () = TestReporter.printSummary();
+    TestReporter.printSummary();
 
     TestReporter.passed() ? exit(0) : exit(1);
   };
 
-  Lwt_main.run(runTests());
+  runTests();
 };

--- a/lib/Rejest.re
+++ b/lib/Rejest.re
@@ -2,7 +2,13 @@ open Types;
 
 let expect = Expect.expect;
 
+module Expect_float = Expect.Expect_float;
+module Expect_string = Expect.Expect_string;
 module Expect_function = Expect_function;
+
+module Expect {
+    module Make = Expect.Make;
+};
 
 let isRunning = ref(false);
 

--- a/lib/TestReporter.re
+++ b/lib/TestReporter.re
@@ -2,9 +2,6 @@
  * TestReporter
  */
 
-open LTerm_style;
-open LTerm_text;
-
 open Types;
 
 type testResultContext = {
@@ -49,79 +46,36 @@ let endTest = (_testName: string, result: testResult) => {
 let printTestResult = (context: testResultContext, level: int) => {
   let padding = String.make(level * 2, ' ');
 
-  let%lwt _ =
-    switch (context.testResult) {
-    | Pass =>
-      LTerm.printls(
-        eval([
-          S(padding),
-          B_bold(true),
-          B_bg(green),
-          S(" PASS "),
-          E_bg,
-          E_bold,
-          S(" "),
-          S(context.testName),
-          E_fg,
-        ]),
-      )
-    | Fail(_) =>
-      LTerm.printls(
-        eval([
-          S(padding),
-          B_bold(true),
-          B_bg(red),
-          S(" FAIL "),
-          E_bg,
-          E_bold,
-          S(" "),
-          S(context.testName),
-          E_fg,
-        ]),
-      )
-    };
-  Lwt.return();
+  switch (context.testResult) {
+  | Pass => print_endline(padding ++ " PASS " ++ context.testName)
+  | Fail(_) => print_endline(padding ++ " FAIL " ++ context.testName)
+  };
 };
 
 let rec printContext = (context: testResultContext, level: int) => {
-  let%lwt _ =
-    context.testName == "__root" ?
-      Lwt.return() : printTestResult(context, level);
+  context.testName == "__root" ? () : printTestResult(context, level);
 
-  Lwt_list.iter_s(c => printContext(c, level + 1), context.children);
+  List.iter(c => printContext(c, level + 1), context.children);
 };
 
 let rec printErrors = (context: testResultContext) => {
-  let%lwt _ =
-    switch (context.testResult) {
-    | Fail(x) =>
-      let%lwt _ = LTerm.printls(eval([S("FAIL: " ++ context.testName)]));
-      let%lwt _ =
-        switch (x) {
-        | ExpectationFailed(_p) =>
-          let%lwt _ =
-            LTerm.printls(
-              eval([S("Expectation Failed: " ++ Printexc.to_string(x))]),
-            );
-          let%lwt _ =
-            LTerm.printls(eval([S("Expected: " ++ _p.expectedValue)]));
-          let%lwt _ =
-            LTerm.printls(eval([S("Actual: " ++ _p.actualValue)]));
-          let%lwt _ = LTerm.printls(eval([S(_p.callstack)]));
-          Lwt.return();
-        | x =>
-          let%lwt _ =
-            LTerm.printls(
-              eval([S("Unhandled exception: " ++ Printexc.to_string(x))]),
-            );
-          Lwt.return();
-        };
-      let%lwt _ = LTerm.printls(eval([S("\n")]));
-      Lwt.return();
-    | _ => Lwt.return()
-    };
+  switch (context.testResult) {
+  | Fail(x) =>
+    print_endline("FAIL: " ++ context.testName);
 
-  Lwt_list.iter_s(c => printErrors(c), context.children);
+    switch (x) {
+    | ExpectationFailed(_p) =>
+      print_endline("Expectation Failed: " ++ Printexc.to_string(x));
+      print_endline("Expected: " ++ _p.expectedValue);
+      print_endline("Actual: " ++ _p.actualValue);
+      print_endline(" Callstack: " ++ _p.callstack);
+    | x => print_endline("Unhandled exception: " ++ Printexc.to_string(x))
+    };
+    print_endline("");
+  | _ => ()
+  };
+
+  List.iter(c => printErrors(c), context.children);
 };
 
 let rec didContextPass = (context: testResultContext) =>
@@ -139,10 +93,9 @@ let rec didContextPass = (context: testResultContext) =>
 let passed = () => didContextPass(rootContext);
 
 let printSummary = () => {
-  let%lwt () = LTerm.printls(eval([S("\n")]));
-  let%lwt () = printContext(rootContext, 0);
-  let%lwt () = LTerm.printls(eval([S("\n")]));
+  print_endline("");
+  printContext(rootContext, 0);
+  print_endline("");
 
-  let%lwt () = printErrors(rootContext);
-  Lwt.return();
+  printErrors(rootContext);
 };

--- a/lib/TestReporter.re
+++ b/lib/TestReporter.re
@@ -47,8 +47,8 @@ let printTestResult = (context: testResultContext, level: int) => {
   let padding = String.make(level * 2, ' ');
 
   switch (context.testResult) {
-  | Pass => print_endline(padding ++ " PASS " ++ context.testName)
-  | Fail(_) => print_endline(padding ++ " FAIL " ++ context.testName)
+  | Pass => print_endline(padding ++ Chalk.bg_green(Chalk.white(Chalk.bold(" PASS "))) ++ " " ++ Chalk.white(context.testName))
+  | Fail(_) => print_endline(padding ++ Chalk.bg_red(Chalk.white(Chalk.bold(" FAIL "))) ++ " " ++  Chalk.white(context.testName))
   };
 };
 
@@ -58,18 +58,20 @@ let rec printContext = (context: testResultContext, level: int) => {
   List.iter(c => printContext(c, level + 1), context.children);
 };
 
+let neutralHighlight = (s) => Chalk.bold(Chalk.white(s))
+
 let rec printErrors = (context: testResultContext) => {
   switch (context.testResult) {
   | Fail(x) =>
-    print_endline("FAIL: " ++ context.testName);
+    print_endline(Chalk.bg_red(Chalk.white(Chalk.bold(" FAIL: "))) ++ " " ++ context.testName);
 
     switch (x) {
     | ExpectationFailed(_p) =>
-      print_endline("Expectation Failed: " ++ Printexc.to_string(x));
-      print_endline("Expected: " ++ _p.expectedValue);
-      print_endline("Actual: " ++ _p.actualValue);
-      print_endline(" Callstack: " ++ _p.callstack);
-    | x => print_endline("Unhandled exception: " ++ Printexc.to_string(x))
+      print_endline(neutralHighlight("Expectation Failed:") ++ " " ++ Printexc.to_string(x));
+      print_endline(neutralHighlight("Expected:") ++ " " ++ _p.expectedValue);
+      print_endline(neutralHighlight("Actual:") ++ " " ++ _p.actualValue);
+      print_endline(neutralHighlight(" Callstack: ") ++ " "  ++ _p.callstack);
+    | x => print_endline(neutralHighlight("Unhandled exception:") ++ " " ++ Printexc.to_string(x))
     };
     print_endline("");
   | _ => ()

--- a/lib/chalk.ml
+++ b/lib/chalk.ml
@@ -1,0 +1,41 @@
+(* This code is from https://github.com/nickzuber/chalk *)
+(* Copyright 2018 Nick Zuber *)
+(* MIT License *)
+
+let bold str = Printf.sprintf "\x1b[1m%s\x1b[0m" str
+let underline str = Printf.sprintf "\x1b[4m%s\x1b[0m" str
+let invert str = Printf.sprintf "\x1b[7m%s\x1b[0m" str
+
+let red str = Printf.sprintf "\x1b[31m%s\x1b[39m" str
+let green str = Printf.sprintf "\x1b[32m%s\x1b[39m" str
+let yellow str = Printf.sprintf "\x1b[33m%s\x1b[39m" str
+let blue str = Printf.sprintf "\x1b[34m%s\x1b[39m" str
+let magenta str = Printf.sprintf "\x1b[35m%s\x1b[39m" str
+let cyan str = Printf.sprintf "\x1b[36m%s\x1b[39m" str
+let gray str = Printf.sprintf "\x1b[90m%s\x1b[39m" str
+let white str = Printf.sprintf "\x1b[97m%s\x1b[39m" str
+
+let light_gray str = Printf.sprintf "\x1b[37m%s\x1b[39m" str
+let light_red str = Printf.sprintf "\x1b[91m%s\x1b[39m" str
+let light_green str = Printf.sprintf "\x1b[92m%s\x1b[39m" str
+let light_yellow str = Printf.sprintf "\x1b[93m%s\x1b[39m" str
+let light_blue str = Printf.sprintf "\x1b[94m%s\x1b[39m" str
+let light_magenta str = Printf.sprintf "\x1b[95m%s\x1b[39m" str
+let light_cyan str = Printf.sprintf "\x1b[96m%s\x1b[39m" str
+
+let bg_red str = Printf.sprintf "\x1b[41m%s\x1b[49m" str
+let bg_green str = Printf.sprintf "\x1b[42m%s\x1b[49m" str
+let bg_yellow str = Printf.sprintf "\x1b[43m%s\x1b[49m" str
+let bg_blue str = Printf.sprintf "\x1b[44m%s\x1b[49m" str
+let bg_magenta str = Printf.sprintf "\x1b[45m%s\x1b[49m" str
+let bg_cyan str = Printf.sprintf "\x1b[46m%s\x1b[49m" str
+let bg_gray str = Printf.sprintf "\x1b[100m%s\x1b[49m" str
+let bg_white str = Printf.sprintf "\x1b[107m%s\x1b[49m" str
+
+let bg_light_gray str = Printf.sprintf "\x1b[47m%s\x1b[49m" str
+let bg_light_red str = Printf.sprintf "\x1b[101m%s\x1b[49m" str
+let bg_light_green str = Printf.sprintf "\x1b[102m%s\x1b[49m" str
+let bg_light_yellow str = Printf.sprintf "\x1b[103m%s\x1b[49m" str
+let bg_light_blue str = Printf.sprintf "\x1b[104m%s\x1b[49m" str
+let bg_light_magenta str = Printf.sprintf "\x1b[105m%s\x1b[49m" str
+let bg_light_cyan str = Printf.sprintf "\x1b[106m%s\x1b[49m" str

--- a/lib/dune
+++ b/lib/dune
@@ -2,5 +2,4 @@
     (name rejest)
     (public_name rejest)
     (flags (:standard -w -33))
-    (preprocess (pps lwt_ppx))
-    (libraries lambda-term))
+    (preprocess (pps lwt_ppx)))

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
         "buildsInSource": "_build"
     },
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "build:js": "esy b dune build test/Test.bc.js",
+        "test:js": "node _build/default/test/Test.bc.js",
+        "test:native": "esy b dune runtest"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,13 @@
         "@esy-ocaml/reason": "^3.3.7",
         "ocaml": "~4.6.0",
         "refmterr": "*",
-        "@opam/lambda-term": "^1.11.0"
+        "@opam/lambda-term": "^1.11.0",
+        "@opam/js_of_ocaml": "*",
+        "@opam/js_of_ocaml-compiler": "*",
+        "@opam/js_of_ocaml-lwt": "*"
+    },
+    "resolutions": {
+        "@esy-ocaml/reason": "github:facebook/reason#d5a26ac"
     },
     "devDependencies": {
         "@esy-ocaml/merlin": "*"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     },
     "homepage": "https://github.com/bryphe/rejest#readme",
     "dependencies": {
+        "@opam/chalk": "1.0",
         "@opam/dune": "^1.5.0",
         "@opam/lwt": "*",
         "@opam/lwt_ppx": "^1.1.0",

--- a/test/Test.re
+++ b/test/Test.re
@@ -3,7 +3,7 @@ open Rejest;
 module Expect_function_test = Expect_function_test;
 
 test("hello world test", () => {
-  expect(1).toEqual(1);
+  expect(1).toEqual(2);
   expect("Hello").toNotEqual("World");
 });
 

--- a/test/Test.re
+++ b/test/Test.re
@@ -3,7 +3,7 @@ open Rejest;
 module Expect_function_test = Expect_function_test;
 
 test("hello world test", () => {
-  expect(1).toEqual(2);
+  expect(1).toEqual(1);
   expect("Hello").toNotEqual("World");
 });
 


### PR DESCRIPTION
This fixes up the library to be compatible with js_of_ocaml. 

In particular, it removes the Lambda_term dependency, and replaces the text coloring by using the chalk implementation here: https://github.com/nickzuber/chalk/blob/master/src/chalk.ml

This also runs `rejest`'s tests with both the native and JSOO strategy.